### PR TITLE
[GDR-1955] unifying normalization types convert_combo_data_to_dt

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.14
+Version: 0.99.15
 Date: 2023-05-12
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
@@ -40,7 +40,7 @@ Suggests:
     BiocStyle,
     futile.logger,
     gDRstyle (>= 0.99.15),
-    gDRtestData (>= 0.99.11),
+    gDRtestData (>= 0.99.12),
     knitr,
     lintr,
     purrr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.15
+- Update after unifying normalization types
+
 # Change to v.0.99.14
 - Fix lintr
 

--- a/R/combo.R
+++ b/R/combo.R
@@ -32,21 +32,8 @@ convert_combo_data_to_dt <-
     my_l <-
       lapply(names(c_assays), function(x) {
         if (x %in% names(get_combo_base_assay_names())) {
-          if (x == names(get_combo_assay_names(group = "combo_base_mx"))) {
-            dt <- convert_se_assay_to_dt(se, c_assays[[x]])
-            for (n in names(ntype_dict)) {
-              data.table::setnames(dt, n, ntype_dict[n], skip_absent = TRUE)
-            }
-            dt <- data.table::melt(
-              dt,
-              measure.vars = as.character(ntype_dict),
-              variable.name = ntype_name,
-              value.name = "base-value"
-            )
-          } else {
             dt <- convert_se_assay_to_dt(se, c_assays[[x]])
             dt[["base-value"]] <- dt[["excess"]]
-          }
         } else {
           dt <- convert_se_assay_to_dt(se, c_assays[[x]])
         }

--- a/R/combo.R
+++ b/R/combo.R
@@ -29,14 +29,7 @@ convert_combo_data_to_dt <-
 
     my_l <-
       lapply(names(c_assays), function(x) {
-        if (x %in% names(get_combo_base_assay_names())) {
-            dt <- convert_se_assay_to_dt(se, c_assays[[x]])
-            if ("excess" %in% names(dt)) {
-              dt[["x"]] <- dt[["excess"]]
-            }
-        } else {
-          dt <- convert_se_assay_to_dt(se, c_assays[[x]])
-        }
+        dt <- convert_se_assay_to_dt(se, c_assays[[x]])
         # TODO: let's discuss how to handle names in isobologram assay (pos_x, iso_level)
         if (prettify) {
           colnames(dt) <-

--- a/man/convert_combo_data_to_dt.Rd
+++ b/man/convert_combo_data_to_dt.Rd
@@ -7,7 +7,7 @@
 convert_combo_data_to_dt(
   se,
   c_assays = get_combo_assay_names(),
-  normalization_type = c("RelativeViability", "GRvalue"),
+  normalization_type = c("RV", "GR"),
   prettify = TRUE
 )
 }

--- a/man/get_combo_col_settings.Rd
+++ b/man/get_combo_col_settings.Rd
@@ -18,6 +18,6 @@ list with colors, breaks and limits
 Get colorscale data for given combo assay and growth metric
 }
 \examples{
-get_combo_col_settings("GRvalue", "smooth")
+get_combo_col_settings("GR", "smooth")
 
 }

--- a/man/get_iso_colors.Rd
+++ b/man/get_iso_colors.Rd
@@ -4,7 +4,7 @@
 \alias{get_iso_colors}
 \title{get_iso_colors}
 \usage{
-get_iso_colors(normalization_type = c("RelativeViability", "GRvalue"))
+get_iso_colors(normalization_type = c("RV", "GR"))
 }
 \arguments{
 \item{normalization_type}{charvec normalization_types expected in the data}

--- a/rplatform/dependencies.yaml
+++ b/rplatform/dependencies.yaml
@@ -1,6 +1,6 @@
 pkgs:
   gDRtestData:
-    ver: '>=0.99.11'
+    ver: '>=0.99.12'
     url: gdrplatform/gDRtestData
     ref: master
     subdir: gDRtestData

--- a/tests/testthat/test-combo.R
+++ b/tests/testthat/test-combo.R
@@ -1,9 +1,8 @@
 library(testthat)
 context("combo-related functions")
-test_mae <- readRDS(system.file(package = "gDRtestData", "testdata", "finalMAE_combo_matrix_small.RDS"))
-test_l <- convert_combo_data_to_dt(test_mae[[1]])
 
-test_that("convert_combo_data_to_dt",  {
+test_that("convert_combo_data_to_dt", {
+  test_mae <- readRDS(system.file(package = "gDRtestData", "testdata", "finalMAE_combo_matrix_small.RDS"))
   res_l <- convert_combo_data_to_dt(test_mae[[1]])
 
   # expected assays converted

--- a/tests/testthat/test-combo.R
+++ b/tests/testthat/test-combo.R
@@ -58,13 +58,13 @@ test_that("get_combo_col_settings",  {
   ### expected values
   gcan <- names(get_combo_assay_names()[1])
   gcc <-
-    get_combo_col_settings(g_metric = "GRvalue", assay_type = gcan)
+    get_combo_col_settings(g_metric = "GR", assay_type = gcan)
   expect_true(inherits(gcc, "list"))
   expect_identical(sort(names(gcc)), c("breaks", "colors", "limits"))
   
   ### errors
   err_msg <- "Assertion on 'assay_type' failed: "
-  expect_error(get_combo_col_settings("GRvalue", 8), err_msg)
+  expect_error(get_combo_col_settings("GR", 8), err_msg)
   err_msg <- "Assertion on 'g_metric' failed: "
   expect_error(get_combo_col_settings("grvalue", 8), err_msg)
 })


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-1955

## Why was it changed?
Change of data model does not fit to assumption for function `gDRutils::convert_combo_data_to_dt` for "SmoothMatrix" assay

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated

# Screenshots (optional)
