### PR TITLE
refactor: add possibility to merge SEs with custom identifiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.20
-Date: 2023-06-07
+Version: 0.99.21
+Date: 2023-06-12
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.21
+- Add support for custom identifiers in merge_SE
+
 # Change to v.0.99.20
 - Switch from `aggregate` to `data.table`
 

--- a/R/merge_SE.R
+++ b/R/merge_SE.R
@@ -25,12 +25,20 @@ merge_SE <- function(SElist,
   checkmate::assert_string(additional_col_name, null.ok = TRUE)
   checkmate::assert_character(discard_keys, null.ok = TRUE)
   
+  
+  SE_identifiers <- unique(lapply(SElist, get_SE_identifiers))[[1]]
+  lapply(names(SE_identifiers), function(x) {
+    gDRutils::set_env_identifier(x, SE_identifiers[[x]])
+  })
+
   discard_keys <- c(discard_keys, unique(unlist(
     lapply(SElist, get_SE_identifiers,
            c("barcode",
              "concentration",
              "concentration2"),
            simplify = FALSE))))
+  
+  
   
   se_assays <- unique(unlist(lapply(SElist,
                                     SummarizedExperiment::assayNames)))
@@ -133,7 +141,6 @@ merge_assay <- function(SElist,
   DT$rId <- DT$cId <- NULL
   discard_keys <- intersect(names(DT), c(discard_keys, additional_col_name))
   BM <- df_to_bm_assay(DT, discard_keys = discard_keys)
-
   list(DT = DT, BM = BM)
 }
 

--- a/tests/testthat/test-merge_SE.R
+++ b/tests/testthat/test-merge_SE.R
@@ -39,6 +39,7 @@ test_that("merge_metadata and identify_unique_se_metadata_fields work as expecte
 })
 
 test_that("merge_SE works as expected", {
+  set_env_identifier("cellline", "CELL_LINE_ID")
   mergedSE <- purrr::quietly(merge_SE)(listSE)
   checkmate::expect_class(mergedSE$result, "SummarizedExperiment")
   S4Vectors::metadata(mergedSE$result)[["df_raw_data"]] <- list(NULL)
@@ -50,6 +51,7 @@ test_that("merge_SE works as expected", {
   expect_identical(unique(assayNormalized[[additional_col_name]]), names(listSE))
   expect_identical(SummarizedExperiment::assayNames(listSE[[1]]),
                    SummarizedExperiment::assayNames(mergedSE[[1]]))
+  reset_env_identifiers()
   })
 
 


### PR DESCRIPTION
# Description
## What changed?
Added support for merging custom identifiers in `merge_SE`
Related JIRA issue: GDR-1937

## Why was it changed?
To be able to merge data with non-default identifiers

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
