### PR TITLE
Gdr 2047

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.24
-Date: 2023-06-22
+Version: 0.99.25
+Date: 2023-06-27
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.25
+- Add assert for missing rownames
+
 # Change to v.0.99.24
 - Replaced RDS with qs
 

--- a/R/convert_mae_se_assay_to_dt.R
+++ b/R/convert_mae_se_assay_to_dt.R
@@ -67,7 +67,7 @@ convert_se_assay_to_dt <- function(se,
       x[length(x)] <- gDRutils::extend_normalization_type_name(x[length(x)])
       paste(x[-1], collapse = "_")
       }))
-    dt <- data.table::dcast(dt, dcast_formula, value.var = normalization_cols, sep = "_1")
+    dt <- data.table::dcast(dt, dcast_formula, value.var = normalization_cols)
     dt$id <- NULL 
     if (!all(new_cols %in% names(dt))) {
       new_cols <- gsub("x_", "", new_cols)
@@ -109,6 +109,7 @@ convert_se_assay_to_dt <- function(se,
     as_df <- BumpyMatrix::unsplitAsDataFrame(object, row.field = "rId", column.field = "cId")
     # Retain nested rownames.
     if (retain_nested_rownames) {
+      checkmate::assert_string(rownames(as_df))
       as_df[[paste0(assay_name, "_rownames")]] <- rownames(as_df)
     }
     as_dt <- data.table::as.data.table(as_df)

--- a/R/convert_mae_se_assay_to_dt.R
+++ b/R/convert_mae_se_assay_to_dt.R
@@ -109,7 +109,7 @@ convert_se_assay_to_dt <- function(se,
     as_df <- BumpyMatrix::unsplitAsDataFrame(object, row.field = "rId", column.field = "cId")
     # Retain nested rownames.
     if (retain_nested_rownames) {
-      checkmate::assert_string(rownames(as_df))
+      checkmate::assert_character(rownames(as_df))
       as_df[[paste0(assay_name, "_rownames")]] <- rownames(as_df)
     }
     as_dt <- data.table::as.data.table(as_df)


### PR DESCRIPTION
# Description
## What changed?
Added assert for missing rownames
Related JIRA issue: GDR-2047

## Why was it changed?
To protect us from using wide_structure when we do not have unique values in cols and no rownames in assay data

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
