### PR TITLE
Gdr 2108

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.26
-Date: 2023-07-28
+Version: 0.99.27
+Date: 2023-08-08
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.27
+- Improve the logic of standardize_MAE to keep SE-specific metadata and be able to revert standardization
+
 # Change to v.0.99.26
 - Tidy code
 

--- a/R/standardize_MAE.R
+++ b/R/standardize_MAE.R
@@ -35,7 +35,7 @@ standardize_mae <- function(mae, use_default = TRUE) {
 standardize_se <- function(se, use_default = TRUE) {
   checkmate::assert_class(se, "SummarizedExperiment")
   
-  gDRutils::reset_env_identifiers()
+ reset_env_identifiers()
   idfs <- get_default_identifiers()
   idfs_se <- get_SE_identifiers(se)
   

--- a/R/standardize_MAE.R
+++ b/R/standardize_MAE.R
@@ -39,7 +39,7 @@ standardize_mae <- function(mae, use_default = TRUE) {
 standardize_se <- function(se, use_default = TRUE) {
   checkmate::assert_class(se, "SummarizedExperiment")
   
- reset_env_identifiers()
+  reset_env_identifiers()
   idfs <- get_default_identifiers()
   idfs_se <- get_SE_identifiers(se)
   
@@ -76,16 +76,20 @@ standardize_se <- function(se, use_default = TRUE) {
                                }
                         )
   )
-  mapping_vector <- mapping_df$x
-  names(mapping_vector) <- mapping_df$y
   
-  # Replace rowData, colData and assays
-  rowData(se) <- rename_DFrame(rowData(se), mapping_vector)
-  colData(se) <- rename_DFrame(colData(se), mapping_vector)
-  assayList <- lapply(assays(se), function(x) {
-    rename_bumpy(x, mapping_vector)
-  })
-  assays(se) <- assayList
+  if (length(mapping_df)) {
+    mapping_vector <- mapping_df$x
+    names(mapping_vector) <- mapping_df$y
+    
+    # Replace rowData, colData and assays
+    rowData(se) <- rename_DFrame(rowData(se), mapping_vector)
+    colData(se) <- rename_DFrame(colData(se), mapping_vector)
+    
+    assayList <- lapply(assays(se), function(x) {
+      rename_bumpy(x, mapping_vector)
+    })
+    assays(se) <- assayList
+  }
   se
 }
 

--- a/R/standardize_MAE.R
+++ b/R/standardize_MAE.R
@@ -1,7 +1,9 @@
 #' Standardize MAE by switching from custom identifiers into gDR-default
 #'
 #' @param mae a MultiAssayExperiment object with drug-response data generate by gDR pipeline
-#'
+#' @param use_default boolean indicating whether or not to use default
+#' identifiers for standardization
+#' 
 #' @return mae a MultiAssayExperiment with default gDR identifiers
 #' 
 #' @examples 
@@ -22,6 +24,8 @@ standardize_mae <- function(mae, use_default = TRUE) {
 #' Standardize SE by switching from custom identifiers into gDR-default
 #'
 #' @param se a SummarizedExperiment object with drug-response data generate by gDR pipeline
+#' @param use_default boolean indicating whether or not to use default
+#' identifiers for standardization
 #'
 #' @return se a SummarizedExperiment with default gDR identifiers
 #' 

--- a/R/standardize_MAE.R
+++ b/R/standardize_MAE.R
@@ -10,11 +10,11 @@
 #' standardize_mae(mae)
 #' 
 #' @export
-standardize_mae <- function(mae) {
+standardize_mae <- function(mae, use_default = TRUE) {
   checkmate::assert_class(mae, "MultiAssayExperiment")
   experiments <- names(mae)
   for (experiment in experiments) {
-    mae[[experiment]] <- standardize_se(mae[[experiment]])
+    mae[[experiment]] <- standardize_se(mae[[experiment]], use_default = use_default)
   }
   mae
 }
@@ -32,14 +32,24 @@ standardize_mae <- function(mae) {
 #' standardize_se(se)
 #' 
 #' @export
-standardize_se <- function(se) {
+standardize_se <- function(se, use_default = TRUE) {
   checkmate::assert_class(se, "SummarizedExperiment")
+  
+  gDRutils::reset_env_identifiers()
   idfs <- get_default_identifiers()
   idfs_se <- get_SE_identifiers(se)
   
+  if (use_default) {
+    from_idfs <- idfs_se
+    to_idfs <- idfs
+  } else {
+    from_idfs <- idfs
+    to_idfs <- idfs_se
+  }
+  
   # Extract matching names of identifiers
-  matching_idfs <- .extract_matching_identifiers(idfs,
-                                                 idfs_se)
+  matching_idfs <- .extract_matching_identifiers(to_idfs,
+                                                 from_idfs)
   
   # Extract changed identifiers
   diff_identifiers <- .extract_diff_identifiers(matching_idfs$default,
@@ -49,8 +59,8 @@ standardize_se <- function(se) {
   
   if ("untreated_tag" %in% diff_names) {
     rowData(se) <- .replace_untreated_tag(rowData(se),
-                                          idfs,
-                                          idfs_se)
+                                          to_idfs,
+                                          from_idfs)
   }
   
   # Create mapping vector
@@ -72,7 +82,6 @@ standardize_se <- function(se) {
     rename_bumpy(x, mapping_vector)
   })
   assays(se) <- assayList
-  se <- set_SE_identifiers(se, idfs)
   se
 }
 

--- a/man/gDRutils-package.Rd
+++ b/man/gDRutils-package.Rd
@@ -9,7 +9,7 @@
 package help page
 }
 \description{
-This package contains utility functions used throughout the gDR platform to maniplate data, including converting and validating data structures. This package also has the necessary default constants for gDR platform.
+This package contains utility functions used throughout the gDR platform to fit data, manipulate data, and convert and validate data structures. This package also has the necessary default constants for gDR platform. Many of the functions are utilized by the gDRcore package.
 }
 \note{
 To learn more about functions start with \code{help(package = "gDRutils")}

--- a/man/standardize_mae.Rd
+++ b/man/standardize_mae.Rd
@@ -4,7 +4,7 @@
 \alias{standardize_mae}
 \title{Standardize MAE by switching from custom identifiers into gDR-default}
 \usage{
-standardize_mae(mae)
+standardize_mae(mae, use_default = TRUE)
 }
 \arguments{
 \item{mae}{a MultiAssayExperiment object with drug-response data generate by gDR pipeline}

--- a/man/standardize_mae.Rd
+++ b/man/standardize_mae.Rd
@@ -8,6 +8,9 @@ standardize_mae(mae, use_default = TRUE)
 }
 \arguments{
 \item{mae}{a MultiAssayExperiment object with drug-response data generate by gDR pipeline}
+
+\item{use_default}{boolean indicating whether or not to use default
+identifiers for standardization}
 }
 \value{
 mae a MultiAssayExperiment with default gDR identifiers

--- a/man/standardize_se.Rd
+++ b/man/standardize_se.Rd
@@ -8,6 +8,9 @@ standardize_se(se, use_default = TRUE)
 }
 \arguments{
 \item{se}{a SummarizedExperiment object with drug-response data generate by gDR pipeline}
+
+\item{use_default}{boolean indicating whether or not to use default
+identifiers for standardization}
 }
 \value{
 se a SummarizedExperiment with default gDR identifiers

--- a/man/standardize_se.Rd
+++ b/man/standardize_se.Rd
@@ -4,7 +4,7 @@
 \alias{standardize_se}
 \title{Standardize SE by switching from custom identifiers into gDR-default}
 \usage{
-standardize_se(se)
+standardize_se(se, use_default = TRUE)
 }
 \arguments{
 \item{se}{a SummarizedExperiment object with drug-response data generate by gDR pipeline}

--- a/tests/testthat/test-standardize_MAE.R
+++ b/tests/testthat/test-standardize_MAE.R
@@ -22,12 +22,7 @@ test_that("standardize_se works as expected",  {
   se@metadata$identifiers$concentration2 <- "dose 2"
   rowData(se) <- rename_DFrame(rowData(se), c("Gnumber" = "druuug"))
   assay(se, "RawTreated") <- rename_bumpy(assay(se, "RawTreated"), c("Concentration_2" = "dose 2"))
-  expect_warning(
-    se_standardized <- standardize_se(se),
-    "overwriting existing metadata entry: 'identifiers'"
-  )
-  expect_equal(lapply(get_SE_identifiers(se_standardized), sort),
-               lapply(get_SE_identifiers(se_original), sort))
+  se_standardized <- standardize_se(se)
   expect_equal(convert_se_assay_to_dt(se_standardized, "RawTreated"),
                convert_se_assay_to_dt(se_original, "RawTreated"))
 })
@@ -42,12 +37,7 @@ test_that("standardize_MAE works as expected",  {
   rowData(mae[[1]]) <- rename_DFrame(rowData(mae[[1]]), c("Gnumber" = "druuug"))
   rowData(mae[[2]]) <- rename_DFrame(rowData(mae[[2]]), c("Gnumber" = "druuug"))
   assay(mae[[1]], "RawTreated") <- rename_bumpy(assay(mae[[1]], "RawTreated"), c("Concentration_2" = "dose 2"))
-  expect_warning(
-    mae_standardized <- standardize_mae(mae),
-    "overwriting existing metadata entry: 'identifiers'"
-  )
-  expect_equal(lapply(get_MAE_identifiers(mae_standardized), lapply, sort),
-               lapply(get_MAE_identifiers(mae_original), lapply, sort))
+  mae_standardized <- standardize_mae(mae)
   expect_equal(convert_mae_assay_to_dt(mae_standardized, "RawTreated"),
                convert_mae_assay_to_dt(mae_original, "RawTreated"))
 })
@@ -61,12 +51,7 @@ test_that("standardize_MAE works with polymapped identifiers",  {
   rowData(mae[[1]]) <- rename_DFrame(rowData(mae[[1]]), c("Gnumber" = "druuug"))
   rowData(mae[[2]]) <- rename_DFrame(rowData(mae[[2]]), c("Gnumber" = "druuug"))
   assay(mae[[1]], "RawTreated") <- rename_bumpy(assay(mae[[1]], "RawTreated"), c("Concentration_2" = "dose 2"))
-  expect_warning(
-    mae_standardized <- standardize_mae(mae),
-    "overwriting existing metadata entry: 'identifiers'"
-  )
-  expect_equal(lapply(get_MAE_identifiers(mae_standardized), lapply, sort),
-               lapply(get_MAE_identifiers(mae_original), lapply, sort))
+  mae_standardized <- standardize_mae(mae)
   expect_equal(convert_mae_assay_to_dt(mae_standardized, "RawTreated"),
                convert_mae_assay_to_dt(mae_original, "RawTreated"))
 })

--- a/tests/testthat/test-standardize_MAE.R
+++ b/tests/testthat/test-standardize_MAE.R
@@ -27,6 +27,18 @@ test_that("standardize_se works as expected",  {
                convert_se_assay_to_dt(se_original, "RawTreated"))
 })
 
+test_that("standardize_se works as expected with default = FALSE",  {
+  se_original <- get_synthetic_data("finalMAE_combo_matrix_small")[[1]]
+  se <- se_original
+  se@metadata$identifiers$drug <- "druuug"
+  se@metadata$identifiers$concentration2 <- "dose 2"
+  rowData(se) <- rename_DFrame(rowData(se), c("Gnumber" = "druuug"))
+  assay(se, "RawTreated") <- rename_bumpy(assay(se, "RawTreated"), c("Concentration_2" = "dose 2"))
+  se_standardized <- standardize_se(standardize_se(se), use_default = FALSE)
+  expect_equal(convert_se_assay_to_dt(se_standardized, "RawTreated"),
+               convert_se_assay_to_dt(se, "RawTreated"))
+})
+
 
 test_that("standardize_MAE works as expected",  {
   mae_original <- get_synthetic_data("finalMAE_combo_matrix_small")


### PR DESCRIPTION
# Description
## What changed?
Improved logic of standardize_MAE
Related JIRA issue: GDR-2108

## Why was it changed?
To be able to standardize and restore default identifiers based on metadata

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
