### PR TITLE
[GDR-2190] Wide table in gDRin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.30
-Date: 2023-09-08
+Version: 0.99.31
+Date: 2023-09-19
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # Change to v.0.99.30
+- Add `wide_structure` param to `convert_mae_assay_to_dt`
+
+# Change to v.0.99.30
 - Updated `experimentalist` description in schema
 
 # Change to v.0.99.29

--- a/R/convert_mae_se_assay_to_dt.R
+++ b/R/convert_mae_se_assay_to_dt.R
@@ -60,10 +60,10 @@ convert_se_assay_to_dt <- function(se,
     dt <- .extract_and_merge_metadata(se, data.table::copy(dt))
   }
   if (wide_structure) {
-    normalization_cols <- grep("^x$|x_+", names(dt), value = TRUE)
     id_col <- paste0(assay_name, "_rownames")
     dt$id <- gsub("_.*", "", dt[[id_col]])
     dt[[id_col]] <- NULL
+    normalization_cols <- grep("^x$|x_+", names(dt), value = TRUE)
     rest_cols <- setdiff(colnames(dt), c(normalization_cols, "normalization_type"))
     dcast_formula <- paste0(paste0(rest_cols, collapse = " + "), " ~  normalization_type")
     new_cols <- as.vector(outer(normalization_cols, unique(dt$normalization_type),

--- a/R/convert_mae_se_assay_to_dt.R
+++ b/R/convert_mae_se_assay_to_dt.R
@@ -122,8 +122,9 @@ convert_se_assay_to_dt <- function(se,
     as_df <- BumpyMatrix::unsplitAsDataFrame(object, row.field = rowfield, column.field = colfield)
     # Retain nested rownames.
     if (retain_nested_rownames) {
-      checkmate::assert_character(rownames(as_df))
-      as_df[[paste0(assay_name, "_rownames")]] <- rownames(as_df)
+      if (is.character(rownames(as_df))) {
+        as_df[[paste0(assay_name, "_rownames")]] <- rownames(as_df)
+      }
     }
     as_dt <- data.table::as.data.table(as_df)
 

--- a/man/convert_mae_assay_to_dt.Rd
+++ b/man/convert_mae_assay_to_dt.Rd
@@ -9,7 +9,8 @@ convert_mae_assay_to_dt(
   assay_name,
   experiment_name = NULL,
   include_metadata = TRUE,
-  retain_nested_rownames = FALSE
+  retain_nested_rownames = FALSE,
+  wide_structure = FALSE
 )
 }
 \arguments{
@@ -30,6 +31,10 @@ nested within a \code{BumpyMatrix} assay.
 Defaults to \code{FALSE}.
 If the \code{assay_name} is not of the \code{BumpyMatrix} class, this argument's value is ignored.
 If \code{TRUE}, the resulting column in the data.table will be named as \code{"<assay_name>_rownames"}.}
+
+\item{wide_structure}{Boolean indicating whether or not to transform data.table into wide format.
+\code{wide_structure = TRUE} requires \code{retain_nested_rownames = TRUE} however that will be validated
+in \code{convert_se_assay_to_dt} function}
 }
 \value{
 data.table representation of the data in \code{assay_name}.
@@ -48,7 +53,7 @@ convert_mae_assay_to_dt(mae, "Metrics")
 
 }
 \seealso{
-flatten
+flatten convert_se_assay_to_dt
 }
 \author{
 Bartosz Czech \href{mailto:bartosz.czech@contractors.roche.com}{bartosz.czech@contractors.roche.com}


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue:  [GDR-2190](https://jira.gene.com/jira/browse/GDR-2190)
* add `wide_structure` param to `convert_mae_assay_to_dt`

## Why was it changed?
* to increase readability of assay tables in gDRin

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)

