### PR TITLE
Debug case of conc=0 for evaluating efficacy with flat fit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.31
-Date: 2023-09-19
+Version: 0.99.32
+Date: 2023-09-22
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# Change to v.0.99.30
+# Change to v.0.99.32
+- Fix bug in the case of conc=0 for evaluating efficacy
+
+# Change to v.0.99.31
 - Add `wide_structure` param to `convert_mae_assay_to_dt`
 
 # Change to v.0.99.30

--- a/R/fit_curves.R
+++ b/R/fit_curves.R
@@ -414,13 +414,9 @@ predict_efficacy_from_conc <- function(c, x_inf, x_0, ec50, h) {
   checkmate::assert_numeric(h)
   assert_equal_input_len(outlier = c, x_inf, x_0, ec50, h)
 
-  unlist(lapply(c, function(c_) {
-    if (c_ > 0) {
-      x_inf + (x_0 - x_inf) / (1 + (c_ / ec50) ^ h)
-    } else { # avoid issues with c=0 for DRCConstantFitResult
-      x_0
-    }
-  }))
+  ifelse(c > 0, 
+         x_inf + (x_0 - x_inf) / (1 + (c / ec50) ^ h), 
+         x_0) # avoid issues with c=0 for DRCConstantFitResult
 }
 
 

--- a/R/fit_curves.R
+++ b/R/fit_curves.R
@@ -414,7 +414,11 @@ predict_efficacy_from_conc <- function(c, x_inf, x_0, ec50, h) {
   checkmate::assert_numeric(h)
   assert_equal_input_len(outlier = c, x_inf, x_0, ec50, h)
 
-  x_inf + (x_0 - x_inf) / (1 + (c / ec50) ^ h)
+  if (c > 0) {
+    x_inf + (x_0 - x_inf) / (1 + (c / ec50) ^ h)
+  } else { # avoid issues with c=0 for DRCConstantFitResult
+    x_0
+  }
 }
 
 

--- a/R/fit_curves.R
+++ b/R/fit_curves.R
@@ -414,11 +414,13 @@ predict_efficacy_from_conc <- function(c, x_inf, x_0, ec50, h) {
   checkmate::assert_numeric(h)
   assert_equal_input_len(outlier = c, x_inf, x_0, ec50, h)
 
-  if (c > 0) {
-    x_inf + (x_0 - x_inf) / (1 + (c / ec50) ^ h)
-  } else { # avoid issues with c=0 for DRCConstantFitResult
-    x_0
-  }
+  vapply(c, function(c_) {
+    if (c_ > 0) {
+      x_inf + (x_0 - x_inf) / (1 + (c_ / ec50) ^ h)
+    } else { # avoid issues with c=0 for DRCConstantFitResult
+      x_0
+    }
+  }, numeric(1))
 }
 
 

--- a/R/fit_curves.R
+++ b/R/fit_curves.R
@@ -414,13 +414,13 @@ predict_efficacy_from_conc <- function(c, x_inf, x_0, ec50, h) {
   checkmate::assert_numeric(h)
   assert_equal_input_len(outlier = c, x_inf, x_0, ec50, h)
 
-  vapply(c, function(c_) {
+  unlist(lapply(c, function(c_) {
     if (c_ > 0) {
       x_inf + (x_0 - x_inf) / (1 + (c_ / ec50) ^ h)
     } else { # avoid issues with c=0 for DRCConstantFitResult
       x_0
     }
-  }, numeric(1))
+  }))
 }
 
 

--- a/tests/testthat/test-fit_curves.R
+++ b/tests/testthat/test-fit_curves.R
@@ -377,3 +377,20 @@ test_that("cap_xc50 works as expected", {
   expect_equal(cap_xc50(xc50 = 1e-6, max_conc = 5, capping_fold = 5), -Inf)
   expect_equal(cap_xc50(xc50 = 1, max_conc = 5, capping_fold = 5), 1)
 })
+
+test_that("predict_efficacy_from_conc works as expected", {
+  # params
+  h <- 2
+  x_inf <- 0.1
+  x_0 <- 1
+  ec50 <- 0.5
+  conc <- c(0, 10 ^ (seq(-3, 1, 0.5)))
+  
+  out <- predict_efficacy_from_conc(conc, x_inf, x_0, ec50, h)
+  
+  res <- c(x_0, 
+           vapply(conc[2:NROW(conc)], 
+                  function(c) x_inf + (x_0 - x_inf) / (1 + (c / ec50) ^ h), numeric(1)))
+  
+  expect_equal(out, res)
+})


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-2198

## Why was it changed?
in the case of a flat fit, evaluating efficacy with  conc=0 will yield NA because of 0/0 operation. It should be x_0.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated

# Screenshots (optional)
