### PR TITLE
[GDR-2227] Treatment instead of template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 0.99.34
-Date: 2023-10-18
+Version: 0.99.35
+Date: 2023-10-24
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 0.99.35 (2023-10-24)
+- add "Treatment" as template identifier
+
 ## 0.99.34 (2023-10-18)
 - adjust NEWS to Bioc format
 

--- a/R/identifiers_list.R
+++ b/R/identifiers_list.R
@@ -24,7 +24,7 @@ IDENTIFIERS_LIST <- list(
 
   well_position = c("WellRow", "WellColumn"),
   concentration = "Concentration",
-  template = "Template",
+  template = c("Template", "Treatment"),
   barcode = c("Barcode", "Plate"),
  
   # ids for the 2nd drug 

--- a/man/gDRutils-package.Rd
+++ b/man/gDRutils-package.Rd
@@ -24,6 +24,7 @@ Authors:
   \item Marc Hafner
   \item Pawel Piatkowski
   \item Dariusz Scigocki
+  \item Janina Smola
   \item Sergiu Mocanu
   \item Allison Vuong
 }

--- a/tests/testthat/test-headers.R
+++ b/tests/testthat/test-headers.R
@@ -1,17 +1,20 @@
 test_that("get_header works", {
   reset_env_identifiers()
-
+  
   expect_error(get_header("BOGUS"))
   expect_equal(get_header("manifest"), list(barcode = c("Barcode", "Plate"),
-                                            template = "Template", duration = "Duration"))
+                                            template = c("Template", "Treatment"),
+                                            duration = "Duration"))
   expect_equal(length(get_header()), 12)
-
+  
   set_env_identifier("duration", "TEST_DURATION")
   expect_equal(get_header("manifest"), list(barcode = c("Barcode", "Plate"),
-                                            template = "Template", duration = "TEST_DURATION"))
-
+                                            template = c("Template", "Treatment"), 
+                                            duration = "TEST_DURATION"))
+  
   reset_env_identifiers()
   expect_equal(get_header("manifest"), list(barcode = c("Barcode", "Plate"),
-                                            template = "Template", duration = "Duration"))
+                                            template = c("Template", "Treatment"), 
+                                            duration = "Duration"))
 })
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2227](https://jira.gene.com/jira/browse/GDR-2227)

## Why was it changed?
`Treatment` is more readable for users than `Template`.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
