### PR TITLE
Gdr 2406

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.1.5
-Date: 2024-02-14
+Version: 1.1.6
+Date: 2024-02-22
 Authors@R: c(person("Bartosz", "Czech", role=c("aut")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
              person("Aleksander", "Chlebowski", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.1.6 (2024-02-22)
+- add fit_source to header list
+
 ## 1.1.5 (2024-02-14)
 - make documentation compatible with pkdgdown
 

--- a/R/headers_list.R
+++ b/R/headers_list.R
@@ -72,6 +72,8 @@
                                       "log2_CI",
                                       "log10_ratio_conc")
   
+  HEADERS_LIST[["fit_source"]] <- "fit_source"
+  
   HEADERS_LIST[["obsolete"]] <- c("RV",
                                   "GR",
                                   "Excess")


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-2406

## Why was it changed?
To not use `fit_source` as an additional perturbation in the data

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
