### PR TITLE
[GDR-2603] Fix issue with wrong order of colorbar values for combo heatmap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.3.5
-Date: 2024-07-12
+Version: 1.3.6
+Date: 2024-07-17
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.3.6 - 2024-07-17
+* update `define_matrix_grid_positions`
+
 ## gDRutils 1.3.5 - 2024-07-12
 * move `get_combo_col_settings` and `get_iso_colors` to `gDRplots` package
 

--- a/R/combo.R
+++ b/R/combo.R
@@ -137,7 +137,7 @@ define_matrix_grid_positions <- function(conc1, conc2) {
     } else if (NROW(x) > 2) {
     2 * x[2] - x[3] - log10(1.5)
     } else {
-      x[2] - 0.5 # diff(log10(c(0, 10^(seq(-3, 1, 0.5)))))
+      x[2] - 0.5 # diff(log10(c(0, 10^(seq(-3, 1, 0.5))))) # nolint
     }
   } 
   

--- a/R/combo.R
+++ b/R/combo.R
@@ -137,7 +137,7 @@ define_matrix_grid_positions <- function(conc1, conc2) {
     } else if (NROW(x) > 2) {
     2 * x[2] - x[3] - log10(1.5)
     } else {
-      x[2] - 0.5
+      x[2] - 0.5 # diff(log10(c(0, 10^(seq(-3, 1, 0.5)))))
     }
   } 
   

--- a/R/combo.R
+++ b/R/combo.R
@@ -132,7 +132,13 @@ define_matrix_grid_positions <- function(conc1, conc2) {
   checkmate::assert_numeric(conc2)
   
   .generate_gap_for_single_agent <- function(x) {
+    if (NROW(x) == 1) {
+      x
+    } else if (NROW(x) > 2) {
     2 * x[2] - x[3] - log10(1.5)
+    } else {
+      x[2] - 0.5
+    }
   } 
   
   conc_1 <- sort(unique(round_concentration(conc1)))

--- a/tests/testthat/test-combo.R
+++ b/tests/testthat/test-combo.R
@@ -82,6 +82,16 @@ test_that("define_matrix_grid_positions", {
   expect_equal(res_2$axis_1, res$axis_1)
   expect_equal(dim(res_2$axis_2), c(0, 4))
   
+  res_3 <-  define_matrix_grid_positions(conc, c(1.2))
+  expect_is(res_3, "list")
+  expect_length(res_3, 2)
+  expect_equal(res_3[["axis_2"]]$pos_x, log10(1.2))
+  
+  res_4 <-  define_matrix_grid_positions(conc, c(0, 1.2))
+  expect_is(res_4, "list")
+  expect_length(res_4, 2)
+  expect_equal(res_4[["axis_2"]][conc_2 == 0, ]$pos_x, log10(1.2) - 0.5)
+  
   expect_error(define_matrix_grid_positions(conc, LETTERS[1:5]))
   expect_error(define_matrix_grid_positions(NULL, conc))
 })


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2603](https://jira.gene.com/jira/browse/GDR-2603)

Update for specific situation with co-dilution data, when `Concentration_2` has only two values, eg. c(0, 1.4)

## Why was it changed?

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
