### PR TITLE
chore: add minor improvement in the logic of `average_biological_repl…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.5.3
-Date: 2024-12-02
+Version: 1.5.4
+Date: 2024-12-09
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.5.4 - 2024-12-09
+* minor improvement in the logic of `average_biological_replicates` (new blacklisted column)
+
 ## gDRutils 1.5.3 - 2024-12-02
 * refactor `set_unique_*` functions
 

--- a/R/headers_list.R
+++ b/R/headers_list.R
@@ -219,7 +219,7 @@
      # parental identifier
      "cellline_parental_identifier",
      "Parental Identifier", # sometimes suffixes incorrectly differentiate this field
-     "parental_identifier", # sometimes suffixes incorrectly differentiate this field
+     "parental_identifier" # sometimes suffixes incorrectly differentiate this field
    )
   )
 }

--- a/R/headers_list.R
+++ b/R/headers_list.R
@@ -217,7 +217,7 @@
      "Reference Division Time", # sometimes this field has `NA`s
      "ReferenceDivisionTime",
      # parental identifier
-     "cellline_parental_identifier"
+     "cellline_parental_identifier",
      "Parental Identifier", # sometimes suffixes incorrectly differentiate this field
      "parental_identifier", # sometimes suffixes incorrectly differentiate this field
    )

--- a/R/headers_list.R
+++ b/R/headers_list.R
@@ -214,6 +214,7 @@
      "Reference Division Time", # sometimes this field has `NA`s
      "cellline_ref_div_time",
      "Parental Identifier", # sometimes suffixes incorrectly differentiate this field
+     "parental_identifier", # sometimes suffixes incorrectly differentiate this field
      "cellline_parental_identifier"
    )
   )

--- a/R/headers_list.R
+++ b/R/headers_list.R
@@ -209,13 +209,17 @@
    # in order to avoid duplicates in the application we have to exclude some fields from 
    # recognizing duplicates in averaging
    blacklisted = c(
-     "Tissue", # sometimes this field is missing
+     # tissue
      "cellline_tissue",
-     "Reference Division Time", # sometimes this field has `NA`s
+     "Tissue", # sometimes this field is missing
+     # reference division time
      "cellline_ref_div_time",
+     "Reference Division Time", # sometimes this field has `NA`s
+     "ReferenceDivisionTime",
+     # parental identifier
+     "cellline_parental_identifier"
      "Parental Identifier", # sometimes suffixes incorrectly differentiate this field
      "parental_identifier", # sometimes suffixes incorrectly differentiate this field
-     "cellline_parental_identifier"
    )
   )
 }


### PR DESCRIPTION

# Description
Minor improvement in the logic of `average_biological_replicates` (new blacklisted column)
## What changed?
A new blacklisted column was added, affecting average_biological_replicates` 
Related JIRA issue: 
GDR-2797

## Why was it changed?

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
