### PR TITLE
feat: make split_SE_components working correctly for sa assay data, m…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.5.4
-Date: 2024-12-09
+Version: 1.5.5
+Date: 2024-12-10
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.5.5 - 2024-12-10
+* make split_SE_components working correctly for sa assay data, modified with `avearge_biological_duplicates`
+
 ## gDRutils 1.5.4 - 2024-12-09
 * minor improvement in the logic of `average_biological_replicates` (new blacklisted column)
 

--- a/R/headers_list.R
+++ b/R/headers_list.R
@@ -112,7 +112,11 @@
     "x",
     "x_std",
     "std_RelativeViability",
-    "std_GRvalue"
+    "std_GRvalue",
+    # after averaging for biological replicates
+    "count",
+    "x_sd",
+    "x_std_sd"
   )
 }
 
@@ -132,7 +136,22 @@
     "p_value",
     "rss",
     "x_sd_avg",
-    "fit_type"
+    "fit_type",
+    # after averaging for biological replicates
+    "count",
+    "x_mean_sd",
+    "x_AOC_sd", 
+    "x_AOC_range_sd",
+    "xc50_sd",                
+    "x_max_sd",
+    "ec50_sd",
+    "x_inf_sd",
+    "x_0_sd", 
+    "h_sd",
+    "r2_sd",
+    "x_sd_avg_sd",
+    "maxlog10Concentration_sd",
+    "N_conc_sd"               
   )
 }
 

--- a/R/split_SE_components.R
+++ b/R/split_SE_components.R
@@ -56,11 +56,11 @@ split_SE_components <- function(df_, nested_keys = NULL, combine_on = 1L) {
   df_ <- S4Vectors::DataFrame(df_, check.names = FALSE)
   all_cols <- colnames(df_)
   # Identify known data fields.
-  data_fields <- c(get_header("raw_data"), get_header("normalized_results"),
+  data_fields <- unique(c(get_header("raw_data"), get_header("normalized_results"),
                    get_header("averaged_results"),
     get_header("metrics_results"), get_env_identifiers("concentration", simplify = TRUE),
     identifiers_md$well_position, identifiers_md$template, nested_keys,
-    get_header("scores"), get_header("excess"), get_header("isobolograms"))
+    get_header("scores"), get_header("excess"), get_header("isobolograms")))
   data_fields <- unique(data_fields)
   data_cols <- data_fields[data_fields %in% all_cols]
   md_cols <- setdiff(all_cols, data_cols) 


### PR DESCRIPTION
# Description
feat: make split_SE_components working correctly for sa assay data, modified with avearge_biological_duplicates

## What changed?
list of columns recognized of data in metrics and averaged assays
Related JIRA issue: 
GDR-2801

## Why was it changed?
feat: make split_SE_components working correctly for sa assay data, modified with avearge_biological_duplicates


# Checklist for sustainable code base
- [ ] I added tests for any code changed/added [TODO]
- [ ] I added documentation for any code changed/added [TODO]
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
