### PR TITLE
feat: add support for unifying metadata in convert_se_assay_to_dt fun…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.5.6
-Date: 2025-01-13
+Version: 1.5.7
+Date: 2025-01-27
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.5.7 - 2025-01-27
+* add support for unifying metadata in `convert_se_assay_to_dt` function
+
 ## gDRutils 1.5.6 - 2025-01-13
 * refactor `remove_drug_batch`
 

--- a/R/convert_mae_se_assay_to_dt.R
+++ b/R/convert_mae_se_assay_to_dt.R
@@ -18,6 +18,8 @@
 #' If \code{TRUE}, the resulting column in the data.table will be named as \code{"<assay_name>_rownames"}.
 #' @param wide_structure Boolean indicating whether or not to transform data.table into wide format.
 #' `wide_structure = TRUE` requires `retain_nested_rownames = TRUE`.
+#' @param unify_metadata Boolean indicating whether to unify DrugName and CellLineName in cases where DrugNames
+#' and CellLineNames are shared by more than one Gnumber and/or clid within the experiment.
 #' @keywords convert
 #'
 #' @return data.table representation of the data in \code{assay_name}.
@@ -33,7 +35,8 @@ convert_se_assay_to_dt <- function(se,
                                    assay_name,
                                    include_metadata = TRUE,
                                    retain_nested_rownames = FALSE,
-                                   wide_structure = FALSE) {
+                                   wide_structure = FALSE,
+                                   unify_metadata = FALSE) {
   checkmate::assert_class(se, "SummarizedExperiment")
   checkmate::assert_string(assay_name)
   checkmate::assert_flag(include_metadata)
@@ -82,6 +85,10 @@ convert_se_assay_to_dt <- function(se,
     if (!any(duplicated(new_cols_rename))) {
       data.table::setnames(dt, new_cols, new_cols_rename, skip_absent = TRUE)
     }
+  }
+  if (unify_metadata) {
+    dt <- gDRutils::set_unique_drug_names_dt(dt)
+    dt <- gDRutils::set_unique_cl_names_dt(dt)
   }
   dt
 }

--- a/man/convert_se_assay_to_dt.Rd
+++ b/man/convert_se_assay_to_dt.Rd
@@ -9,7 +9,8 @@ convert_se_assay_to_dt(
   assay_name,
   include_metadata = TRUE,
   retain_nested_rownames = FALSE,
-  wide_structure = FALSE
+  wide_structure = FALSE,
+  unify_metadata = FALSE
 )
 }
 \arguments{
@@ -29,6 +30,9 @@ If \code{TRUE}, the resulting column in the data.table will be named as \code{"<
 
 \item{wide_structure}{Boolean indicating whether or not to transform data.table into wide format.
 \code{wide_structure = TRUE} requires \code{retain_nested_rownames = TRUE}.}
+
+\item{unify_metadata}{Boolean indicating whether to unify DrugName and CellLineName in cases where DrugNames
+and CellLineNames are shared by more than one Gnumber and/or clid within the experiment.}
 }
 \value{
 data.table representation of the data in \code{assay_name}.

--- a/tests/testthat/test-convert_mae_se_assay_to_dt.R
+++ b/tests/testthat/test-convert_mae_se_assay_to_dt.R
@@ -82,6 +82,13 @@ test_that("merge_metrics argument of assay_to_dt works as expected", {
   expect_true(extra_col %in% colnames(obs2))
   expect_equal(metrics2[[extra_col]], extra_val)
   expect_true(all(colnames(get_header("metrics_names")) %in% colnames(obs2)))
+  
+  # unify_metadata works in covert_se_assay_to_dt
+  se <- get_synthetic_data("finalMAE_small")[[1]][c(seq_len(3)), 1]
+  rowData(se)$DrugName[[2]] <- rowData(se)$DrugName[[1]]
+  metrics_dt <- convert_se_assay_to_dt(se, "Metrics", unify_metadata = TRUE)
+  expect_equal(unique(metrics_dt$Gnumber), unique(rowData(se)$Gnumber))
+  expect_equal(unique(metrics_dt$DrugName), c("drug_002 (G00002)", "drug_002 (G00003)", "drug_004"))
 })
 
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-2522

## Why was it changed?
To add support for unifying metadata in `convert_se_assay_to_dt` function

# Checklist for sustainable code base
- [X] I added tests for any code changed/added
- [X] I added documentation for any code changed/added
- [X] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
