### PR TITLE
feat: refactor average_biological_replicates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.5.11
-Date: 2025-02-14
+Version: 1.5.12
+Date: 2025-02-21
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.5.12 - 2025-02-21
+* refactor average_across_biological_replipcates
+
 ## gDRutils 1.5.11 - 2025-02-14
 * update default value of `capping_fold` param in `cap_assay_infinities`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## gDRutils 1.5.12 - 2025-02-21
-* refactor average_across_biological_replipcates
+* refactor average_biological_replicates
 
 ## gDRutils 1.5.11 - 2025-02-14
 * update default value of `capping_fold` param in `cap_assay_infinities`

--- a/R/utils.R
+++ b/R/utils.R
@@ -458,7 +458,7 @@ average_biological_replicates_dt <- function(
     add_sd = FALSE) {
   
   checkmate::assert_data_table(dt)
-  checkmate::assert_character(var)
+  checkmate::assert_character(var, null.ok = FALSE, any.missing = FALSE)
   checkmate::assert_flag(prettified)
   checkmate::assert_character(geometric_average_fields)
   checkmate::assert_character(fit_type_average_fields)

--- a/R/utils.R
+++ b/R/utils.R
@@ -458,7 +458,7 @@ average_biological_replicates_dt <- function(
     add_sd = FALSE) {
   
   checkmate::assert_data_table(dt)
-  checkmate::assert_string(var)
+  checkmate::assert_character(var)
   checkmate::assert_flag(prettified)
   checkmate::assert_character(geometric_average_fields)
   checkmate::assert_character(fit_type_average_fields)
@@ -477,6 +477,8 @@ average_biological_replicates_dt <- function(
   }
   
   average_fields <- setdiff(names(Filter(is.numeric, data)), c(unlist(pidfs), var, iso_cols))
+  # don't  average across _sd$ fields (to avoid adding unexpected columns, i.e. x_sd_sd_sd_sd)
+  average_fields <- grep("_sd$", average_fields, invert = TRUE, value = TRUE)
   geometric_average_fields <- intersect(geometric_average_fields, names(dt))
   fit_type_average_fields <- intersect(fit_type_average_fields, names(dt))
   blacklisted_fields <- intersect(blacklisted_fields, names(dt))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -251,6 +251,23 @@ test_that("average_biological_replicates_dt works as expected", {
   expect_true(nrow(av1f) == 1)
   av1i <- average_biological_replicates_dt(tdata, var = "source_id", fit_type_average_fields = "bad_value")
   expect_true(nrow(av1i) == 8)
+ 
+  # two additional variables for averaging
+  ligand_data <- get_synthetic_data("finalMAE_wLigand")
+  lmetrics_data <- convert_se_assay_to_dt(ligand_data[[1]], "Metrics")
+  lmetrics_data$source_id <- "ds_small_ligand"
+  
+  sdata <- get_synthetic_data("finalMAE_small")
+  smetrics_data <- convert_se_assay_to_dt(sdata[[1]], "Metrics")
+  smetrics_data$source_id <- "ds_small"
+  
+  lsmetrics_data <- data.table::rbindlist(list(lmetrics_data, smetrics_data), fill = TRUE)
+  avg_vars <- get_additional_variables(lsmetrics_data)
+  lsmetrics_avg <- average_biological_replicates_dt(lsmetrics_data, var = avg_vars, add_sd = TRUE)
+  
+  expect_identical(NROW(smetrics_data), NROW(lsmetrics_avg))
+  expect_true(all(avg_vars %in% colnames(lsmetrics_data)))
+  expect_true(all(!avg_vars %in% colnames(lsmetrics_avg)))
   
 })
 


### PR DESCRIPTION
# Description
## What changed?
Support of averaging biological replicates across multiple fields at once
Related JIRA issue:  GDR-2876

## Why was it changed?
```
idt <- data.table::data.table(metric = 1:4, source_id = c(1,1,2,2), duration = 1:2)
> idt
   metric source_id duration
    <int>     <num>    <int>
1:      1         1        1
2:      2         1        2
3:      3         2        1
4:      4         2        2
# imagine that you are averaging a metric in two ways:
# a) iteratively: first by source_id, then by duration
# b) by source_id and duration at once

# The mean value of the metric will be the same in both cases
# a) 
mean(c(mean(1:2), mean(3:4)))
[1] 2.5
# b) 
mean(idt$metric)
[1] 2.5

# The SD will differ
# a) 
sd(c(mean(1:2), mean(3:4)))
[1] 1.414214
# b) 
sd(idt$metric)
[1] 1.290994
```
Let's switch to solution b) to assure proper sd.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
