### PR TITLE
chore: sync main with Bioconductor devel (GDR-3372)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.11.0
-Date: 2026-04-18
+Version: 1.11.1
+Date: 2026-04-29
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.10.0
+Version: 1.11.0
 Date: 2026-04-18
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.9.8
+Version: 1.10.0
 Date: 2026-04-18
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.11.1 - 2026-04-29
+* synchronize Bioconductor and GitHub versioning
+
 ## gDRutils 1.9.8 - 2026-04-18
 * migrate from `qs` to `qs2` package (`qs::qread` → `qs2::qs_read`, `qs::qsave` → `qs2::qs_save`)
 * update batch file extension from `.qs` to `.qs2`


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: https://globaljira.roche.com/browse/GDR-3372

Synced `main` branch with Bioconductor `upstream/devel`. Changes: version bumped to 1.11.1, NEWS.md and DESCRIPTION date updated.

## Why was it changed?
Bioconductor created RELEASE_3_23 branch - maintainers required to sync GitHub with Bioconductor git server.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added (N/A - version bump only)
- [x] I added documentation for any code changed/added (N/A)
- [x] I made sure naming of any new functions is self-explanatory and consistent (N/A)

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)