### PR TITLE
fix: set x_AOC_range in too_few and invalid fit paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.11.3
-Date: 2026-05-27
+Version: 1.11.4
+Date: 2026-06-15
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.11.4 - 2026-06-15
+* set x_AOC_range in too_few and invalid fit fallback paths
+
 ## gDRutils 1.11.3 - 2026-05-27
 * apply updated gDRstyle rules
 

--- a/R/fit_curves.R
+++ b/R/fit_curves.R
@@ -679,6 +679,9 @@ average_dups <- function(dt, col) {
 #' @keywords internal
 .set_too_few_fit_params <- function(out, norm_values) {
   out$fit_type <- "DRCTooFewPointsToFit"
+  mean_norm_value <- mean(norm_values, na.rm = TRUE)
+  out$x_mean <- mean_norm_value
+  out$x_AOC <- out$x_AOC_range <- .calculate_complement(mean_norm_value)
   out$xc50 <- .estimate_xc50(norm_values)
   out
 }
@@ -723,6 +726,9 @@ set_constant_fit_params <- function(out, mean_norm_value) {
 .set_invalid_fit_params <- function(out, norm_values) {
   out$fit_type <- "DRCInvalidFitResult"
   out$r2 <- NA
+  mean_norm_value <- mean(norm_values, na.rm = TRUE)
+  out$x_mean <- mean_norm_value
+  out$x_AOC <- out$x_AOC_range <- .calculate_complement(mean_norm_value)
   out$xc50 <- .estimate_xc50(norm_values)
   out
 }


### PR DESCRIPTION
## Summary
- `.set_too_few_fit_params` and `.set_invalid_fit_params` now set `x_mean`, `x_AOC`, and `x_AOC_range` from the mean of `norm_values`
- Previously these fallback paths did not set `x_AOC_range`, causing downstream report crashes when all fits in a dataset fell through to these paths

## Test plan
- [ ] Existing tests pass
- [ ] Verify `x_AOC_range` is present in output for datasets with too-few-points fits