### PR TITLE
fix: compare package versions numerically in get_gDR_session_info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.11.5
-Date: 2026-07-01
+Version: 1.11.6
+Date: 2026-07-27
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),
              person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.11.6 - 2026-07-27
+* fix `get_gDR_session_info` to compare versions numerically, avoiding false "outdated" warnings (e.g. 0.2.100 vs 0.2.99)
+
 ## gDRutils 1.11.5 - 2026-07-01
 * improve average_biological_replicates_dt performance with GForce-friendly operations
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1476,9 +1476,11 @@ get_gDR_session_info <- function(pattern = "^gDR") {
   }
 
   pkg_data[, UsedVersion := Version[order(match(LibPath, .libPaths()))[1]], by = Package] # nolint
-  pkg_data[, MaxVersion := max(Version), by = Package]
+  pkg_data[, MaxVersion := as.character(max(numeric_version(Version))), by = Package]
 
-  outdated_pkgs <- pkg_data[LibPath != .Library & UsedVersion < MaxVersion, .(Package, UsedVersion, MaxVersion)]
+  outdated_pkgs <- pkg_data[LibPath != .Library &
+                              numeric_version(UsedVersion) < numeric_version(MaxVersion),
+                            .(Package, UsedVersion, MaxVersion)]
 
   if (NROW(outdated_pkgs) > 0) {
     warning_msg <- paste("The following packages have a user version older than the system version:",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1170,7 +1170,7 @@ test_that("get_gDR_session_info behaves correctly under various conditions", {
   # Version comparison must be numeric, not lexicographic (GDR-3499):
   # 0.2.100 is newer than 0.2.99 and must NOT be flagged as outdated.
   ip_semver <- matrix(c(
-    "gDRdummyPackage3", "0.2.100", .libPaths()[1],
+    "gDRdummyPackage3", "0.2.100", .Library,
     "gDRdummyPackage3", "0.2.99", .Library
   ), nrow = 2, byrow = TRUE)
   colnames(ip_semver) <- c("Package", "Version", "LibPath")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1166,4 +1166,19 @@ test_that("get_gDR_session_info behaves correctly under various conditions", {
                 how = ip_correct_versions)
 
   expect_equal(get_gDR_session_info(), exp_dt_correct_versions)
+
+  # Version comparison must be numeric, not lexicographic (GDR-3499):
+  # 0.2.100 is newer than 0.2.99 and must NOT be flagged as outdated.
+  ip_semver <- matrix(c(
+    "gDRdummyPackage3", "0.2.100", .libPaths()[1],
+    "gDRdummyPackage3", "0.2.99", .Library
+  ), nrow = 2, byrow = TRUE)
+  colnames(ip_semver) <- c("Package", "Version", "LibPath")
+
+  mockery::stub(where = get_gDR_session_info,
+                what = "utils::installed.packages",
+                how = ip_semver)
+
+  expect_no_warning(res_semver <- get_gDR_session_info(pattern = "gDRdummyPackage3"))
+  expect_equal(res_semver$Version, "0.2.100")
 })


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3499

`get_gDR_session_info()` now compares package versions numerically using `numeric_version()` instead of lexicographic string comparison in `max()` and `<`.

## Why was it changed?
String comparison of version numbers is incorrect: `max("0.2.100", "0.2.99")` returns `"0.2.99"` because `"9" > "1"` at the third character. This caused a false "user version older than the system version" warning for packages where the used version was actually newer (e.g. 0.2.100 vs 0.2.99). Numeric version comparison fixes this — the warning now fires only when the used version is genuinely older.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated