### PR TITLE
Gdr 3504

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRutils
 Type: Package
 Title: A package with helper functions for processing drug response data
-Version: 1.11.7
+Version: 1.11.8
 Date: 2026-07-28
 Authors@R: c(person("Bartosz", "Czech", role=c("aut"),
                    comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRutils 1.11.8 - 2026-07-29
+* fix `split_SE_components` to return empty list instead of empty data.frame when no constant columns exist
+
 ## gDRutils 1.11.7 - 2026-07-28
 * fix `get_gDR_session_info` to compare versions numerically, avoiding false "outdated" warnings (e.g. 0.2.100 vs 0.2.99)
 

--- a/R/split_SE_components.R
+++ b/R/split_SE_components.R
@@ -80,7 +80,11 @@ split_SE_components <- function(df_, nested_keys = NULL, combine_on = 1L) {
     logical(1))
   # Get experiment columns.
   constant_cols <- remaining_cols[singletons]
-  exp_md <- as.data.frame(unique(md[, constant_cols, with = FALSE])) # nolint
+  exp_md <- if (length(constant_cols) == 0L) {
+    list()
+  } else {
+    as.list(unique(md[, constant_cols, with = FALSE])[1L]) # nolint
+  }
   remaining_cols <- remaining_cols[!singletons]
   # Identify cellline properties by checking what columns have only a 1:1 mapping for each cell line.
   cl_subset_cols <- c(unname(unlist(cell_cols)), remaining_cols)

--- a/R/split_SE_components.R
+++ b/R/split_SE_components.R
@@ -80,11 +80,7 @@ split_SE_components <- function(df_, nested_keys = NULL, combine_on = 1L) {
     logical(1))
   # Get experiment columns.
   constant_cols <- remaining_cols[singletons]
-  exp_md <- if (length(constant_cols) == 0L) {
-    list()
-  } else {
-    as.list(unique(md[, constant_cols, with = FALSE])[1L]) # nolint
-  }
+  exp_md <- as.list(unique(md[, constant_cols, with = FALSE])[1L]) # nolint
   remaining_cols <- remaining_cols[!singletons]
   # Identify cellline properties by checking what columns have only a 1:1 mapping for each cell line.
   cl_subset_cols <- c(unname(unlist(cell_cols)), remaining_cols)

--- a/tests/testthat/test-split_SE_Components.R
+++ b/tests/testthat/test-split_SE_Components.R
@@ -70,6 +70,39 @@ test_that("split_SE_components works with colnames with -", {
   expect_true("fix5-aza" %in% names(md$treatment_md))
 })
 
+test_that("split_SE_components always returns experiment_md as a list", {
+  # Case 1: no constant columns -> empty list
+  df_no_const <- data.table::data.table(
+    clid = c("CL1", "CL2"),
+    Gnumber = c("DrugA", "DrugB"),
+    ReadoutValue = c(1.0, 2.0)
+  )
+  md_no_const <- split_SE_components(df_no_const)
+  expect_true(is.list(md_no_const$experiment_md))
+  expect_false(is.data.frame(md_no_const$experiment_md))
+  expect_equal(length(md_no_const$experiment_md), 0L)
+
+  # Case 2: constant columns present -> named list with the constant value
+  # BatchNumber is not a known identifier so it lands in experiment_md when constant
+  df_const <- data.table::data.table(
+    clid = c("CL1", "CL2"),
+    Gnumber = c("DrugA", "DrugB"),
+    Duration = c(72, 72),
+    BatchNumber = c("B1", "B1"),
+    ReadoutValue = c(1.0, 2.0)
+  )
+  md_const <- split_SE_components(df_const)
+  expect_true(is.list(md_const$experiment_md))
+  expect_false(is.data.frame(md_const$experiment_md))
+  expect_true(length(md_const$experiment_md) > 0L)
+  expect_equal(md_const$experiment_md[["BatchNumber"]], "B1")
+
+  # Case 3: standard test_df -> still a list
+  md_std <- split_SE_components(test_df)
+  expect_true(is.list(md_std$experiment_md))
+  expect_false(is.data.frame(md_std$experiment_md))
+})
+
 test_that("split_SE_components sorts non-default columns", {
   test_df3 <- data.table::copy(test_df)
   test_df3$`fix5-aza` <- sample(c(0.5, 0), size = NROW(test_df3), replace = TRUE)


### PR DESCRIPTION
# Description
## What changed?
`split_SE_components` always returns `experiment_md` as a `list`.
Related JIRA issue: GDR-3504

## Why was it changed?
`as.data.frame()` produced inconsistent types depending on input, causing a crash in downstream `$`-assignment on an empty `data.frame`.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated
